### PR TITLE
[MRG] Fix the auto generated link in "edit on gh" button

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -61,7 +61,7 @@ html_context = {
   'display_github': True,
   'github_user': 'blocksigner',
   'github_repo': 'business-guide',
-  'github_version': 'master/'
+  'github_version': 'master/source/'
 }
 
 html_theme_options = {


### PR DESCRIPTION
The link at the top right that takes you to the source on GitHub was broken.