### PR TITLE
[MRG] Build output in a sub-directory for netlify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+_output/
 build/
 default.profraw

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,8 @@ help:
 
 netlify: html
 	rm -rf _output
-	mkdir -p _output/business
-	cp -a build/html/ _output/business/
-
+	mkdir -p _output/business-guide
+	cp -a build/html/. _output/business-guide/
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ help:
 
 .PHONY: help Makefile
 
+netlify: html
+	rm -rf _output
+	mkdir -p _output/business
+	cp -a build/html/ _output/business/
+
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = "_output"
+  command = "make netlify"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
 [build]
   publish = "_output"
   command = "make netlify"
+
+[[redirects]]
+  from = "/"
+  to = "/business-guide"
+  status = 302


### PR DESCRIPTION
This PR will move the output so that it is in a sub-directory of the main domain.

To help with "docs as code" we move the build config to `netlify.toml` instead of using the Netlify UI.

https://deploy-preview-30--skribble-business-docs.netlify.app/business-guide/ as example of hosting the page at a sub-directory.