### PR TITLE
[MRG] Move from business-guide to business-admin as directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ help:
 
 netlify: html
 	rm -rf _output
-	mkdir -p _output/business-guide
-	cp -a build/html/. _output/business-guide/
+	mkdir -p _output/business-admin
+	cp -a build/html/. _output/business-admin/
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,5 +4,5 @@
 
 [[redirects]]
   from = "/"
-  to = "/business-guide"
+  to = "/business-admin"
   status = 302


### PR DESCRIPTION
The guide should be hosted at docs.skribble.com/business-admin not business-guide.