### PR TITLE
Configure canonical URLs for pages

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -66,9 +66,9 @@ html_context = {
   'github_version': 'master/source/'
 }
 
+html_baseurl = "https://docs.skribble.com/business-admin/"
+
 html_theme_options = {
-    # Makes it very dark so disabled for now
-    # "style_nav_header_background": "#293D66",
 }
 
 # Don't include the reST sources HTML build as _sources


### PR DESCRIPTION
Help the search engine robots know which page is the "real" page to avoid duplicate content