### PR TITLE
fix(layout.html): update href as requested to point to /de-de

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -1,7 +1,7 @@
 {% extends "!layout.html" %}
 {%- block sidebartitle %}
 
-<a href="https://skribble.com" class="icon icon-title"> {{ project }}
+<a href="https://www.skribble.com/de-de/" class="icon icon-title"> {{ project }}
 
 {%- if logo %}
   {#- Not strictly valid HTML, but it's the only way to display/scale


### PR DESCRIPTION
On request by Tim R.
Updates the logo icon in the top left to point directly to a new url.

Previously: `https://skribble.com`
Updated: `https://www.skribble.com/de-de/`